### PR TITLE
Add Rust example for bech32-encoded entities (NIP19)

### DIFF
--- a/snippets/rust/src/main.rs
+++ b/snippets/rust/src/main.rs
@@ -2,15 +2,16 @@
 #![allow(unused_variables)]
 
 mod event;
+mod hello;
 mod keys;
 mod messages;
 mod nip01;
-mod nip44;
-mod nip59;
-mod hello;
 mod nip17;
+mod nip19;
+mod nip44;
 mod nip47;
 mod nip49;
+mod nip59;
 
 #[tokio::main]
 async fn main() {}

--- a/snippets/rust/src/nip19.rs
+++ b/snippets/rust/src/nip19.rs
@@ -1,0 +1,103 @@
+use nostr_sdk::nips::nip19::Nip19Profile;
+use nostr_sdk::prelude::*;
+use nostr_sdk::FromBech32;
+use nostr_sdk::ToBech32;
+use std::collections::HashMap;
+
+pub fn nip19() -> Result<()> {
+    // Generate random keys
+    let keys = Keys::generate();
+
+    // ANCHOR: nip19-npub
+    println!("Public keys: {:?}", keys.public_key.to_bech32()?);
+    // ANCHOR_END: nip19-npub
+
+    // ANCHOR: nip19-nsec
+    println!("Secret key: {:?}", keys.secret_key().to_bech32()?);
+    // ANCHOR_END: nip19-nsec
+
+    // ANCHOR: nip19-note
+    let event =
+        EventBuilder::text_note("Hello from Rust Nostr rust Bindings!").sign_with_keys(&keys)?;
+    println!("Event  : {:?}", event.id.to_bech32()?);
+    // ANCHOR_END: nip19-note
+
+    println!("Shareable identifiers with extra metadata (bech32):");
+    // ANCHOR: nip19-nprofile-encode
+    // Create NIP-19 profile including relays data
+    let relay_url = RelayUrl::parse("wss://relay.damus.io")?;
+    let relays = vec![relay_url];
+    let nprofile = Nip19Profile::new(keys.public_key, &relays)?;
+    println!("Profile (encoded): {}", nprofile.to_bech32()?);
+    // ANCHOR_END: nip19-nprofile-encode
+
+    // ANCHOR: nip19-nprofile-decode
+    // Decode NIP-19 profile
+    let decode_nprofile = Nip19Profile::from_bech32(&nprofile.to_bech32()?)?;
+    println!("NIP-19 profile decoded");
+    println!("Public key: {}", decode_nprofile.public_key);
+    for (idx, relay) in decode_nprofile.relays.iter().enumerate() {
+        println!("{},{}", idx, relay);
+    }
+    // ANCHOR_END: nip19-nprofile-decode
+
+    // ANCHOR: nip19-nevent-encode
+    // Create NIP-19 event including author and relays data
+    let nevent = Nip19Event::new(event.id)
+        .author(keys.public_key)
+        .relays(relays.clone());
+    let encoded_nevent = nevent.to_bech32()?;
+    println!("Event (encoded): {}", encoded_nevent);
+    // ANCHOR_END: nip19-nevent-encode
+
+    // ANCHOR: nip19-nevent-decode
+    // Decode NIP-19 event
+    let decoded_event = Nip19Event::from_bech32(&encoded_nevent)?;
+    let mut decoded_event_map = HashMap::new();
+    decoded_event_map.insert("event_id", decoded_event.event_id.to_bech32()?);
+    decoded_event_map.insert(
+        "author",
+        match decoded_event.author {
+            Some(pub_key) => pub_key.to_bech32()?,
+            None => "None".to_string(),
+        },
+    );
+    decoded_event_map.insert(
+        "kind",
+        match decoded_event.kind {
+            Some(kind) => kind.to_string(),
+            None => "None".to_string(),
+        },
+    );
+    decoded_event_map.insert(
+        "relays",
+        decoded_event
+            .relays
+            .iter()
+            .map(|r| r.to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+
+    println!("Event (decoded)");
+    for (key, value) in decoded_event_map {
+        println!("{} : {}", key, value)
+    }
+    // ANCHOR_END: nip19-nevent-decode
+
+    // ANCHOR: nip19-naddr-encode
+    // Create NIP-19 coordinate
+    let kind = Kind::TextNote;
+    let coord = Coordinate::new(kind, keys.public_key);
+    let coordinate = Nip19Coordinate::new(coord, &relays)?;
+    let bech_32_coordinate = coordinate.to_bech32()?;
+    println!(" Coordinate (encoded): {}", bech_32_coordinate);
+    // ANCHOR_END: nip19-naddr-encode
+
+    // ANCHOR: nip19-naddr-decode
+    // Decode NIP-19 coordinate
+    let decode_coord = Nip19Coordinate::from_bech32(&bech_32_coordinate)?;
+    println!("Coordinate (decoded): {:?}", decode_coord);
+    // ANCHOR_END: nip19-naddr-decode
+    Ok(())
+}

--- a/src/sdk/nips/19.md
+++ b/src/sdk/nips/19.md
@@ -1,10 +1,10 @@
 ## NIP-19: bech32-encoded entities
 
-Bech32 encoding is used for the primary purpose of transportability between users/client/applications. 
-In addition to bech-32 encoding of the data a series of prefixes are also used to help easily differentiate between different data objects. 
-`npub`/`nsec` for public and private keys, respectively and `note` for note ids. 
+Bech32 encoding is used for the primary purpose of transportability between users/client/applications.
+In addition to bech-32 encoding of the data a series of prefixes are also used to help easily differentiate between different data objects.
+`npub`/`nsec` for public and private keys, respectively and `note` for note ids.
 
-Extra metadata may be included when communicating between applications to make cross compatibility more streamlined. 
+Extra metadata may be included when communicating between applications to make cross compatibility more streamlined.
 These follow a type-length-value structure and have the following possible prefixes: `nprofile`, `nevent`, `nrelay` and `naddr`.
 
 <custom-tabs category="lang">
@@ -12,7 +12,53 @@ These follow a type-length-value structure and have the following possible prefi
 <div slot="title">Rust</div>
 <section>
 
-TODO
+For most of these examples you will see that the `to_bech32()` and `from_bech32()` methods generally facilitate encoding or decoding objects per the NIP-19 standard.
+
+Public and Private (or secret) keys in `npub` and `nsec` formats.
+
+```rust,ignore
+{{#include ../../../snippets/rust/src/nip19.rs:nip19-npub}}
+```
+
+```rust,ignore
+{{#include ../../../snippets/rust/src/nip19.rs:nip19-nsec}}
+```
+
+Simple note presented in NIP-19 format.
+
+```rust,ignore
+{{#include ../../../snippets/rust/src/nip19.rs:nip19-note}}
+```
+
+Using the `Nip19Profile` struct to create a shareable `nprofile` that includes relay data to help other applications to locate the profile data. This is followed by decoding the event object.
+
+```rust,ignore
+{{#include ../../../snippets/rust/src/nip19.rs:nip19-nprofile-encode}}
+```
+
+```rust,ignore
+{{#include ../../../snippets/rust/src/nip19.rs:nip19-nprofile-decode}}
+```
+
+Using the `Nip19Event` struct to create a shareable `nevent` that includes author and relay data. This is followed by decoding the event object.
+
+```rust,ignore
+{{#include ../../../snippets/rust/src/nip19.rs:nip19-nevent-encode}}
+```
+
+```rust,ignore
+{{#include ../../../snippets/rust/src/nip19.rs:nip19-nevent-decode}}
+```
+
+Using the `Coordinate` struct to generate the coordinates for a replaceable event (in this case Metadata).
+
+```rust,ignore
+{{#include ../../../snippets/rust/src/nip19.rs:nip19-naddr-encode}}
+```
+
+```rust,ignore
+{{#include ../../../snippets/rust/src/nip19.rs:nip19-naddr-decode}}
+```
 
 </section>
 


### PR DESCRIPTION
closes #2 

## Description

This pull request introduces a new example demonstrating the implementation of NIP-19 in Rust using the `nostr-sdk`. The following changes have been made:

- Provided Rust code snippets illustrating the concept.
- Added snippets to the NIP-19 markdown doc

## How to Test for Reviewers

- Bootstrap a new Rust project:
  ```bash
  cargo new my_project
  cd my_project
  ```

- In `Cargo.toml`, add the following dependencies:
  ```toml
  [dependencies]
  nostr-sdk = { version = "0.40", features = ["all-nips"] }
  nostr-relay-builder = "0.40"
  ```

- Copy snippets from [snippets/rust/src/nip19.rs](https://github.com/AdamuAbba/book/blob/bbd75ef1db93d4e0cdf9c913173d98bec6ae3a5f/snippets/rust/src/nip19.rs) to your `main.rs` file, and test to ensure functionality.



