### PR TITLE
theme: add custom dark and light themes matching website colors

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,9 +10,10 @@ build-dir = "output"
 create-missing = false
 
 [output.html]
-default-theme = "auto"
-preferred-dark-theme = "ayu"
+default-theme = "dark"
+preferred-dark-theme = "dark"
 additional-js = ["tabs.js"]
+additional-css = ["theme/css/nostrdevkit_theme.css"]
 git-repository-url = "https://github.com/nostrdevkit/book"
 site-url = "/"
 cname = "doc.nostrdevkit.org"

--- a/theme/css/nostrdevkit_theme.css
+++ b/theme/css/nostrdevkit_theme.css
@@ -1,0 +1,224 @@
+.dark {
+    --bg: #0b0714;
+    --fg: #f7f2ff;
+
+    --accent: #8b5cf6;
+    --line: #33264c;
+
+    --sidebar-bg: #171026;
+    --sidebar-fg: #c8bdd8;
+    --sidebar-non-existant: #9587aa;
+    --sidebar-active: #8b5cf6;
+    --sidebar-spacer: #33264c;
+    --sidebar-header-border-color: #583a9b;
+
+    --scrollbar: var(--sidebar-fg);
+
+    --icons: #9587aa;
+    --icons-hover: #d8b4fe;
+
+    --links: #8b5cf6;
+
+    --inline-code-color: #d8b4fe;
+
+    --theme-popup-bg: #171026;
+    --theme-popup-border: #33264c;
+    --theme-hover: #1e1235;
+
+    --quote-bg: #120b22;
+    --quote-border: #33264c;
+
+    --warning-border: #8b5cf6;
+
+    --table-border-color: #33264c;
+    --table-header-bg: #120b22;
+    --table-alternate-bg: #171026;
+
+    --searchbar-border-color: #33264c;
+    --searchbar-bg: #171026;
+    --searchbar-fg: #f7f2ff;
+    --searchbar-shadow-color: #d8b4fe;
+    --searchresults-header-fg: #9587aa;
+    --searchresults-border-color: #33264c;
+    --searchresults-li-bg: #120b22;
+    --search-mark-bg: #d8b4fe;
+
+    --color-scheme: dark;
+
+    --hl-keyword: #c084fc;
+    --hl-string: #6ee7b7;
+    --hl-comment: #9587aa;
+    --hl-number: #8ab4ff;
+    --hl-function: #d8b4fe;
+    --hl-type: #8b5cf6;
+    --hl-literal: #c084fc;
+    --hl-meta: #9587aa;
+    --hl-attr: #d8b4fe;
+
+    --code-bg: #171026;
+    --code-fg: #f7f2ff;
+    --content-shadow: 0 2px 8px rgba(31, 8, 61, 0.2);
+
+    --copy-button-filter: invert(50%) sepia(10%) saturate(500%) hue-rotate(250deg) brightness(100%) contrast(85%);
+    --copy-button-filter-hover: invert(48%) sepia(50%) saturate(4000%) hue-rotate(230deg) brightness(100%) contrast(95%);
+
+    --footnote-highlight: #8ab4ff;
+
+    --overlay-bg: rgba(11, 7, 20, 0.4);
+}
+
+.light {
+    /* Background & Text */
+    --bg: #faf8ff;
+    --fg: #1a1025;
+
+    --accent: #8b5cf6;
+    --line: #d4c8e8;
+
+    /* Sidebar */
+    --sidebar-bg: #f0ebf8;
+    --sidebar-fg: #4a3b63;
+    --sidebar-non-existant: #8c7daa;
+    --sidebar-active: #8b5cf6;
+    --sidebar-spacer: #d4c8e8;
+    --sidebar-header-border-color: #6e6edb;
+
+    --scrollbar: var(--sidebar-fg);
+
+    --icons: #8c7daa;
+    --icons-hover: #6d28d9;
+
+    --links: #8b5cf6;
+
+    --inline-code-color: #c084fc;
+
+    --theme-popup-bg: #ffffff;
+    --theme-popup-border: #d4c8e8;
+    --theme-hover: #f3eefb;
+
+    --quote-bg: #f4f0fa;
+    --quote-border: #d4c8e8;
+
+    --warning-border: #8b5cf6;
+
+    --table-border-color: #d4c8e8;
+    --table-header-bg: #f4f0fa;
+    --table-alternate-bg: #faf8ff;
+
+    --searchbar-border-color: #d4c8e8;
+    --searchbar-bg: #ffffff;
+    --searchbar-fg: #1a1025;
+    --searchbar-shadow-color: #c084fc;
+    --searchresults-header-fg: #8c7daa;
+    --searchresults-border-color: #d4c8e8;
+    --searchresults-li-bg: #f4f0fa;
+    --search-mark-bg: #e9d5ff;
+
+    --color-scheme: light;
+
+    --hl-keyword: #8b5cf6;
+    --hl-string: #059669;
+    --hl-comment: #8c7daa;
+    --hl-number: #6d8cff;
+    --hl-function: #7c3aed;
+    --hl-type: #8b5cf6;
+    --hl-literal: #c084fc;
+    --hl-meta: #8c7daa;
+    --hl-attr: #7c3aed;
+
+    --code-bg: #f4f0fa;
+    --code-fg: #1a1025;
+    --content-shadow: 0 2px 8px rgba(31, 8, 61, 0.1);
+
+    --copy-button-filter: invert(55%) sepia(12%) saturate(900%) hue-rotate(230deg) brightness(100%) contrast(90%);
+    --copy-button-filter-hover: invert(25%) sepia(98%) saturate(3000%) hue-rotate(250deg) brightness(100%) contrast(95%);
+
+    --footnote-highlight: #c084fc;
+
+    --overlay-bg: rgba(23, 16, 38, 0.4);
+}
+
+body {
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.hljs {
+    background: var(--code-bg) !important;
+    color: var(--code-fg) !important;
+}
+
+::selection {
+    background: #8b5cf6;
+    color: #ffffff;
+}
+
+pre, code {
+    border-radius: 6px;
+}
+.content pre {
+    box-shadow: var(--content-shadow);
+    border: 1px solid var(--quote-border);
+}
+
+:not(pre) > code {
+    background: var(--quote-bg);
+    padding: 1px 5px;
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar {
+    width: 8px;
+}
+::-webkit-scrollbar-track {
+    background: var(--bg);
+}
+::-webkit-scrollbar-thumb {
+    background: var(--line);
+    border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+    background: var(--accent);
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-type {
+    color: var(--hl-keyword);
+}
+
+.hljs-literal,
+.hljs-built_in {
+    color: var(--hl-literal);
+}
+
+.hljs-string,
+.hljs-addition,
+.hljs-regexp,
+.hljs-attribute {
+    color: var(--hl-string);
+}
+
+.hljs-number,
+.hljs-variable,
+.hljs-template-variable {
+    color: var(--hl-number);
+}
+
+.hljs-comment,
+.hljs-meta {
+    color: var(--hl-comment);
+    font-style: italic;
+}
+
+.hljs-attr {
+    color: var(--hl-attr);
+}
+
+.hljs-title.function_,
+.hljs-title {
+    color: var(--hl-function);
+}
+
+.hljs-strong {
+    font-weight: bold;
+}

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -1,0 +1,367 @@
+<!DOCTYPE HTML>
+<html lang="{{ language }}" class="{{ default_theme }} sidebar-visible" dir="{{ text_direction }}">
+    <head>
+        <!-- Book generated using mdBook -->
+        <meta charset="UTF-8">
+        <title>{{ title }}</title>
+        {{#if is_print }}
+        <meta name="robots" content="noindex">
+        {{/if}}
+        {{#if base_url}}
+        <base href="{{ base_url }}">
+        {{/if}}
+
+
+        <!-- Custom HTML head -->
+        {{> head}}
+
+        <meta name="description" content="{{ description }}">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="theme-color" content="#ffffff">
+
+        {{#if favicon_svg}}
+        <link rel="icon" href="{{ resource "favicon.svg" }}">
+        {{/if}}
+        {{#if favicon_png}}
+        <link rel="shortcut icon" href="{{ resource "favicon.png" }}">
+        {{/if}}
+        <link rel="stylesheet" href="{{ resource "css/variables.css" }}">
+        <link rel="stylesheet" href="{{ resource "css/general.css" }}">
+        <link rel="stylesheet" href="{{ resource "css/chrome.css" }}">
+        {{#if print_enable}}
+        <link rel="stylesheet" href="{{ resource "css/print.css" }}" media="print">
+        {{/if}}
+
+        <!-- Fonts -->
+        <link rel="stylesheet" href="{{ resource "fonts/fonts.css" }}">
+
+        <!-- Highlight.js Stylesheets -->
+        <link rel="stylesheet" id="mdbook-highlight-css" href="{{ resource "highlight.css" }}">
+        <link rel="stylesheet" id="mdbook-tomorrow-night-css" href="{{ resource "tomorrow-night.css" }}">
+        <link rel="stylesheet" id="mdbook-ayu-highlight-css" href="{{ resource "ayu-highlight.css" }}">
+
+        <!-- Custom theme stylesheets -->
+        {{#each additional_css}}
+        <link rel="stylesheet" href="{{ resource this }}">
+        {{/each}}
+
+        {{#if mathjax_support}}
+        <!-- MathJax -->
+        <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        {{/if}}
+
+        <!-- Provide site root and default themes to javascript -->
+        <script>
+            const path_to_root = "{{ path_to_root }}";
+            const default_light_theme = "{{ default_theme }}";
+            const default_dark_theme = "{{ preferred_dark_theme }}";
+        {{#if search_js}}
+            window.path_to_searchindex_js = "{{ resource "searchindex.js" }}";
+        {{/if}}
+        </script>
+        <!-- Start loading toc.js asap -->
+        <script src="{{ resource "toc.js" }}"></script>
+    </head>
+    <body>
+    <div id="mdbook-help-container">
+        <div id="mdbook-help-popup">
+            <h2 class="mdbook-help-title">Keyboard shortcuts</h2>
+            <div>
+                <p>Press <kbd>←</kbd> or <kbd>→</kbd> to navigate between chapters</p>
+                {{#if search_enabled}}
+                <p>Press <kbd>S</kbd> or <kbd>/</kbd> to search in the book</p>
+                {{/if}}
+                <p>Press <kbd>?</kbd> to show this help</p>
+                <p>Press <kbd>Esc</kbd> to hide this help</p>
+            </div>
+        </div>
+    </div>
+    <div id="mdbook-body-container">
+        <!-- Work around some values being stored in localStorage wrapped in quotes -->
+        <script>
+            try {
+                let theme = localStorage.getItem('mdbook-theme');
+                let sidebar = localStorage.getItem('mdbook-sidebar');
+
+                if (theme.startsWith('"') && theme.endsWith('"')) {
+                    localStorage.setItem('mdbook-theme', theme.slice(1, theme.length - 1));
+                }
+
+                if (sidebar.startsWith('"') && sidebar.endsWith('"')) {
+                    localStorage.setItem('mdbook-sidebar', sidebar.slice(1, sidebar.length - 1));
+                }
+            } catch (e) { }
+        </script>
+
+        <!-- Set the theme before any content is loaded, prevents flash -->
+        <script>
+            const default_theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? default_dark_theme : default_light_theme;
+            let theme;
+            try { theme = localStorage.getItem('mdbook-theme'); } catch(e) { }
+            if (theme === null || theme === undefined) { theme = default_theme; }
+            const html = document.documentElement;
+            html.classList.remove('{{ default_theme }}')
+            html.classList.add(theme);
+            html.classList.add("js");
+        </script>
+
+        <input type="checkbox" id="mdbook-sidebar-toggle-anchor" class="hidden">
+
+        <!-- Hide / unhide sidebar before it is displayed -->
+        <script>
+            let sidebar = null;
+            const sidebar_toggle = document.getElementById("mdbook-sidebar-toggle-anchor");
+            if (document.body.clientWidth >= 1080) {
+                try { sidebar = localStorage.getItem('mdbook-sidebar'); } catch(e) { }
+                sidebar = sidebar || 'visible';
+            } else {
+                sidebar = 'hidden';
+                sidebar_toggle.checked = false;
+            }
+            if (sidebar === 'visible') {
+                sidebar_toggle.checked = true;
+            } else {
+                html.classList.remove('sidebar-visible');
+            }
+        </script>
+
+        <nav id="mdbook-sidebar" class="sidebar" aria-label="Table of contents">
+            <!-- populated by js -->
+            <mdbook-sidebar-scrollbox class="sidebar-scrollbox"></mdbook-sidebar-scrollbox>
+            <noscript>
+                <iframe class="sidebar-iframe-outer" src="{{ path_to_root }}toc.html"></iframe>
+            </noscript>
+            <div id="mdbook-sidebar-resize-handle" class="sidebar-resize-handle">
+                <div class="sidebar-resize-indicator"></div>
+            </div>
+        </nav>
+
+        <div id="mdbook-page-wrapper" class="page-wrapper">
+
+            <div class="page">
+                {{> header}}
+                <div id="mdbook-menu-bar-hover-placeholder"></div>
+                <div id="mdbook-menu-bar" class="menu-bar sticky">
+                    <div class="left-buttons">
+                        <label id="mdbook-sidebar-toggle" class="icon-button" for="mdbook-sidebar-toggle-anchor" title="Toggle Table of Contents" aria-label="Toggle Table of Contents" aria-controls="mdbook-sidebar">
+                            {{fa "solid" "bars"}}
+                        </label>
+                        <button id="mdbook-theme-toggle" class="icon-button" type="button" title="Change theme" aria-label="Change theme" aria-haspopup="true" aria-expanded="false" aria-controls="mdbook-theme-list">
+                            {{fa "solid" "paintbrush"}}
+                        </button>
+                        <ul id="mdbook-theme-list" class="theme-popup" aria-label="Themes" role="menu">
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-dark">Dark</button></li>
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-light">Light</button></li>
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-rust">Rust</button></li>
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-coal">Coal</button></li>
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-navy">Navy</button></li>
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-ayu">Ayu</button></li>
+                        </ul>
+                        {{#if search_enabled}}
+                        <button id="mdbook-search-toggle" class="icon-button" type="button" title="Search (`/`)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="/ s" aria-controls="mdbook-searchbar">
+                            {{fa "solid" "magnifying-glass"}}
+                        </button>
+                        {{/if}}
+                    </div>
+
+                    <h1 class="menu-title">{{ book_title }}</h1>
+
+                    <div class="right-buttons">
+                        {{#if print_enable}}
+                        <a href="{{ path_to_root }}print.html" title="Print this book" aria-label="Print this book">
+                            {{fa "solid" "print" "print-button"}}
+                        </a>
+                        {{/if}}
+                        {{#if git_repository_url}}
+                        <a href="{{git_repository_url}}" title="Git repository" aria-label="Git repository">
+                            {{fa git_repository_icon_class git_repository_icon}}
+                        </a>
+                        {{/if}}
+                        {{#if git_repository_edit_url}}
+                        <a href="{{git_repository_edit_url}}" title="Suggest an edit" aria-label="Suggest an edit" rel="edit">
+                            {{fa "solid" "pencil" "git-edit-button"}}
+                        </a>
+                        {{/if}}
+
+                    </div>
+                </div>
+
+                {{#if search_enabled}}
+                <div id="mdbook-search-wrapper" class="hidden">
+                    <form id="mdbook-searchbar-outer" class="searchbar-outer">
+                        <div class="search-wrapper">
+                            <input type="search" id="mdbook-searchbar" name="searchbar" placeholder="Search this book ..." aria-controls="mdbook-searchresults-outer" aria-describedby="searchresults-header">
+                            <div class="spinner-wrapper">
+                                {{fa "solid" "spinner" "fa-spin"}}
+                            </div>
+                        </div>
+                    </form>
+                    <div id="mdbook-searchresults-outer" class="searchresults-outer hidden">
+                        <div id="mdbook-searchresults-header" class="searchresults-header"></div>
+                        <ul id="mdbook-searchresults">
+                        </ul>
+                    </div>
+                </div>
+                {{/if}}
+
+                <!-- Apply ARIA attributes after the sidebar and the sidebar toggle button are added to the DOM -->
+                <script>
+                    document.getElementById('mdbook-sidebar-toggle').setAttribute('aria-expanded', sidebar === 'visible');
+                    document.getElementById('mdbook-sidebar').setAttribute('aria-hidden', sidebar !== 'visible');
+                    Array.from(document.querySelectorAll('#mdbook-sidebar a')).forEach(function(link) {
+                        link.setAttribute('tabIndex', sidebar === 'visible' ? 0 : -1);
+                    });
+                </script>
+
+                <div id="mdbook-content" class="content">
+                    <main>
+                        {{{ content }}}
+                    </main>
+
+                    <nav class="nav-wrapper" aria-label="Page navigation">
+                        <!-- Mobile navigation buttons -->
+                        {{#if previous}}
+                            <a rel="prev" href="{{ path_to_root }}{{previous.link}}" class="mobile-nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
+                                {{#if (eq ../text_direction "rtl")}}
+                                {{fa "solid" "angle-right"}}
+                                {{else}}
+                                {{fa "solid" "angle-left"}}
+                                {{/if}}
+                            </a>
+                        {{/if}}
+
+                        {{#if next}}
+                            <a rel="next prefetch" href="{{ path_to_root }}{{next.link}}" class="mobile-nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
+                                {{#if (eq ../text_direction "rtl")}}
+                                {{fa "solid" "angle-left"}}
+                                {{else}}
+                                {{fa "solid" "angle-right"}}
+                                {{/if}}
+                            </a>
+                        {{/if}}
+
+                        <div style="clear: both"></div>
+                    </nav>
+                </div>
+            </div>
+
+            <nav class="nav-wide-wrapper" aria-label="Page navigation">
+                {{#if previous}}
+                    <a rel="prev" href="{{ path_to_root }}{{previous.link}}" class="nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
+                        {{#if (eq ../text_direction "rtl")}}
+                        {{fa "solid" "angle-right"}}
+                        {{else}}
+                        {{fa "solid" "angle-left"}}
+                        {{/if}}
+                    </a>
+                {{/if}}
+
+                {{#if next}}
+                    <a rel="next prefetch" href="{{ path_to_root }}{{next.link}}" class="nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
+                        {{#if (eq text_direction "rtl")}}
+                        {{fa "solid" "angle-left"}}
+                        {{else}}
+                        {{fa "solid" "angle-right"}}
+                        {{/if}}
+                    </a>
+                {{/if}}
+            </nav>
+
+        </div>
+
+        <template id=fa-eye>{{fa "solid" "eye"}}</template>
+        <template id=fa-eye-slash>{{fa "solid" "eye-slash"}}</template>
+        <template id=fa-copy>{{fa "regular" "copy"}}</template>
+        <template id=fa-play>{{fa "solid" "play"}}</template>
+        <template id=fa-clock-rotate-left>{{fa "solid" "clock-rotate-left"}}</template>
+
+        {{#if live_reload_endpoint}}
+        <!-- Livereload script (if served using the cli tool) -->
+        <script>
+            const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+            const wsAddress = wsProtocol + "//" + location.host + "/" + "{{{live_reload_endpoint}}}";
+            const socket = new WebSocket(wsAddress);
+            socket.onmessage = function (event) {
+                if (event.data === "reload") {
+                    socket.close();
+                    location.reload();
+                }
+            };
+
+            window.onbeforeunload = function() {
+                socket.close();
+            }
+        </script>
+        {{/if}}
+
+        {{#if playground_line_numbers}}
+        <script>
+            window.playground_line_numbers = true;
+        </script>
+        {{/if}}
+
+        {{#if playground_copyable}}
+        <script>
+            window.playground_copyable = true;
+        </script>
+        {{/if}}
+
+        {{#if playground_js}}
+        <script src="{{ resource "ace.js" }}"></script>
+        <script src="{{ resource "mode-rust.js" }}"></script>
+        <script src="{{ resource "editor.js" }}"></script>
+        <script src="{{ resource "theme-dawn.js" }}"></script>
+        <script src="{{ resource "theme-tomorrow_night.js" }}"></script>
+        {{/if}}
+
+        {{#if search_js}}
+        <script src="{{ resource "elasticlunr.min.js" }}"></script>
+        <script src="{{ resource "mark.min.js" }}"></script>
+        <script src="{{ resource "searcher.js" }}"></script>
+        {{/if}}
+
+        <script src="{{ resource "clipboard.min.js" }}"></script>
+        <script src="{{ resource "highlight.js" }}"></script>
+        <script src="{{ resource "book.js" }}"></script>
+
+        <!-- Custom JS scripts -->
+        {{#each additional_js}}
+        <script src="{{ resource this}}"></script>
+        {{/each}}
+
+        {{#if is_print}}
+        {{#if mathjax_support}}
+        <script>
+        window.addEventListener('load', function() {
+            MathJax.Hub.Register.StartupHook('End', function() {
+                window.setTimeout(window.print, 100);
+            });
+        });
+        </script>
+        {{else}}
+        <script>
+        window.addEventListener('load', function() {
+            window.setTimeout(window.print, 100);
+        });
+        </script>
+        {{/if}}
+        {{/if}}
+
+        {{#if fragment_map}}
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                const fragmentMap =
+                    {{{fragment_map}}}
+                ;
+                const target = fragmentMap[window.location.hash];
+                if (target) {
+                    let url = new URL(target, window.location.href);
+                    window.location.replace(url.href);
+                }
+            });
+        </script>
+        {{/if}}
+
+    </div>
+    </body>
+</html>


### PR DESCRIPTION
A new cool themes that match the new website theme (https://nostrdevkit.org). I'm not a UI designer, this done by the help of an AI.

| Dark | Light |
| :--: | :--:|
| <img width="1919" height="927" alt="image" src="https://github.com/user-attachments/assets/d8e68427-a9d1-4d1d-be40-5e04146dc3e2" /> | <img width="1919" height="927" alt="image" src="https://github.com/user-attachments/assets/78e0fdca-2002-4aab-8636-dc9dfc4a08fc" /> |
| <img width="474" height="871" alt="image" src="https://github.com/user-attachments/assets/52778824-e12e-4fcc-b7a6-3f85cc379ce2" /> | <img width="474" height="871" alt="image" src="https://github.com/user-attachments/assets/8437ddf0-fff8-458a-a634-83279a26b32a" /> |
| <img width="474" height="871" alt="image" src="https://github.com/user-attachments/assets/ce88c2e3-99cb-48e1-9866-bca91e3fff7b" /> | <img width="474" height="871" alt="image" src="https://github.com/user-attachments/assets/1eb949e7-1b36-4649-b2b9-013bbb7436c5" /> |